### PR TITLE
Add voltage calibration to flower reader

### DIFF
--- a/flower/utils.py
+++ b/flower/utils.py
@@ -7,13 +7,17 @@ from scipy.ndimage import maximum_filter1d, minimum_filter1d
 
 
 
-def read_flower_data(path, read_calibrated_data=False):
+def read_flower_data(path, read_data_in_volts=False):
     """Read flower data from a file/run.
 
     Parameters
     ----------
     path : str
         Path to the file or run directory.
+    
+    read_data_in_volts : bool
+        If True, will convert adc to volts by applying a linear conversion and
+        factoring out the digital flower gain
 
     Returns
     -------
@@ -73,7 +77,7 @@ def read_flower_data(path, read_calibrated_data=False):
     json_data["atten"] = atten
     json_data["flower_gains"] = flower_gains
 
-    if read_calibrated_data:
+    if read_data_in_volts:
         volts_per_adc = adc_input_range / (2**nr_bits - 1)
         gain_amplification = trigger_board_amplifications[flower_gains]
 
@@ -81,8 +85,8 @@ def read_flower_data(path, read_calibrated_data=False):
         nr_channels = len(flower_gains)
         for i,event in enumerate(events):
             for channel_id in range(nr_channels):
-                events[i]["ch"+str(channel_id)] = [wf*volts_per_adc/gain_amplification[channel_id]
-                                                   for wf in events[i]["ch"+str(channel_id)]]
+                events[i]["ch" + str(channel_id)] = [wf*volts_per_adc/gain_amplification[channel_id]
+                                                     for wf in events[i]["ch"+str(channel_id)]]
 
 
     return json_data
@@ -165,7 +169,7 @@ def calculate_snr(trace, coincidence_window_size, signal_window=None, noise_wind
 
 class flowerDataset():
     """
-    Helper class for handling flower data, does require NuRadio ro be installed
+    Helper class for handling flower data, does require NuRadio to be installed
     """
     def __init__(self, filepath):
         from NuRadioReco.utilities.fft import time2freq, freq2time

--- a/flower/utils.py
+++ b/flower/utils.py
@@ -2,6 +2,7 @@ import json
 import gzip
 import os
 import libconf
+import matplotlib.pyplot as plt
 import numpy as np
 from scipy.ndimage import maximum_filter1d, minimum_filter1d
 
@@ -213,8 +214,8 @@ class flowerDataset():
         saves an frequency spectrum averaged over the run in this dataset
         """
         import pickle
-        from NuRadioReco.utilities.fft import time2freq, freq2time
-        frequencies = np.fft.rfftfreq(self.nr_samples, d=1./self.sampling_rate)
+        from NuRadioReco.utilities.fft import freqs, time2freq, freq2time
+        frequencies = freqs(self.nr_samples, self.sampling_rate)
         
         spectra = time2freq(self.wfs, self.sampling_rate)
         if filt is not None:

--- a/flower/utils.py
+++ b/flower/utils.py
@@ -171,9 +171,10 @@ class flowerDataset():
     """
     Helper class for handling flower data, does require NuRadio to be installed
     """
-    def __init__(self, filepath):
+    def __init__(self, filepath, read_data_in_volts):
         from NuRadioReco.utilities.fft import time2freq, freq2time
-        data_dict = read_flower_data(filepath)
+        data_dict = read_flower_data(filepath, read_data_in_volts=read_data_in_volts)
+        self.in_volts = read_data_in_volts
 
         
         self.station_id = data_dict["station"]

--- a/flower/utils.py
+++ b/flower/utils.py
@@ -98,8 +98,8 @@ def read_flower_data(path, read_data_in_volts=False):
         nr_channels = len(flower_gains)
         for i,event in enumerate(events):
             for channel_id in range(nr_channels):
-                events[i]["ch" + str(channel_id)] = [wf*volts_per_adc/gain_amplification[channel_id]
-                                                     for wf in events[i]["ch"+str(channel_id)]]
+                events[i]["ch" + str(channel_id)] = [adc*volts_per_adc/gain_amplification[channel_id]
+                                                     for adc in events[i]["ch"+str(channel_id)]]
 
 
     return json_data


### PR DESCRIPTION
Adds the option to calibrate the flower data in the flower reader under flower.utils. The code reads the flower gain codes and divides out the extra digital gain amplification. The file also includes a helper class for reading flower data and saving spectra.